### PR TITLE
Add config option to disable replanning.

### DIFF
--- a/cfg/TebLocalPlannerReconfigure.cfg
+++ b/cfg/TebLocalPlannerReconfigure.cfg
@@ -437,4 +437,14 @@ grp_recovery_divergence.add(
     100
 )
 
+grp_recovery.add(
+    "global_planner_reset_when_trajectory_infeasible",
+    bool_t,
+    0,
+    "True to enable global planner replanning when TEB is unable to find feasible trajectory. "
+    "If this parameter is false then TEB will just wait until trajectory becomes feasible "
+    "(e.g. path blocking obstacle is removed).",
+    True
+)
+
 exit(gen.generate("teb_local_planner", "teb_local_planner", "TebLocalPlannerReconfigure"))

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -221,6 +221,7 @@ public:
     double oscillation_filter_duration; //!< Filter length/duration [sec] for the detection of oscillations
     bool divergence_detection_enable; //!< True to enable divergence detection.
     int divergence_detection_max_chi_squared; //!< Maximum acceptable Mahalanobis distance above which it is assumed that the optimization diverged.
+    bool global_planner_reset_when_trajectory_infeasible; //!< True to enable replanning when no feasible trajectory could be found.
   } recovery; //!< Parameters related to recovery and backup strategies
 
 

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -175,6 +175,7 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("oscillation_filter_duration", recovery.oscillation_filter_duration, recovery.oscillation_filter_duration);
   nh.param("divergence_detection", recovery.divergence_detection_enable, recovery.divergence_detection_enable);
   nh.param("divergence_detection_max_chi_squared", recovery.divergence_detection_max_chi_squared, recovery.divergence_detection_max_chi_squared);
+  nh.param("global_planner_reset_when_trajectory_infeasible", recovery.global_planner_reset_when_trajectory_infeasible, recovery.global_planner_reset_when_trajectory_infeasible);
 
   checkParameters();
   checkDeprecated(nh);
@@ -289,6 +290,7 @@ void TebConfig::reconfigure(TebLocalPlannerReconfigureConfig& cfg)
   recovery.oscillation_recovery = cfg.oscillation_recovery;
   recovery.divergence_detection_enable = cfg.divergence_detection_enable;
   recovery.divergence_detection_max_chi_squared = cfg.divergence_detection_max_chi_squared;
+  recovery.global_planner_reset_when_trajectory_infeasible = cfg.global_planner_reset_when_trajectory_infeasible;
 
   
   checkParameters();


### PR DESCRIPTION
Add config option to disable replanning (with global planner), when there's no feasible trajectory.